### PR TITLE
Update URL pattern to use uri-template format

### DIFF
--- a/schemas/2025-12-11/server.schema.json
+++ b/schemas/2025-12-11/server.schema.json
@@ -513,7 +513,7 @@
         "url": {
           "description": "Server-Sent Events endpoint URL template. Variables in {curly_braces} are resolved based on context: In Package context, they reference argument valueHints, argument names, or environment variable names from the parent Package. In Remote context, they reference variables from the transport's 'variables' object. After variable substitution, this should produce a valid URI.",
           "example": "https://mcp-fs.example.com/sse",
-          "pattern": "^https?://[^\\s]+$",
+          "format": "uri-template",
           "type": "string"
         }
       },
@@ -559,7 +559,7 @@
         "url": {
           "description": "URL template for the streamable-http transport. Variables in {curly_braces} are resolved based on context: In Package context, they reference argument valueHints, argument names, or environment variable names from the parent Package. In Remote context, they reference variables from the transport's 'variables' object. After variable substitution, this should produce a valid URI.",
           "example": "https://api.example.com/mcp",
-          "pattern": "^https?://[^\\s]+$",
+          "format": "uri-template",
           "type": "string"
         }
       },


### PR DESCRIPTION
In the description it already mentions that this is an URL Template. The regexp is more restrictive than this. 

Our actual problem is: MCP Servers might not know their full absolute URL, this is often defined later, e.g. by the Gateway. So for some MCP servers, they can only provide a relative URL or a templated URI. 

Is this correct or are there reasons why the current regexp insists on an absolute URL? I understand we want absolute URLs at the very end (in the registry), but when you self-describe yourself you might not yet have it.